### PR TITLE
Anti windup p pd

### DIFF
--- a/src/DiscretePIDs.jl
+++ b/src/DiscretePIDs.jl
@@ -75,7 +75,11 @@ function DiscretePID(;
     0 ≤ b ≤ 1 || throw(ArgumentError("b must be ∈ [0, 1]"))
     umax > umin || throw(ArgumentError("umax must be greater than umin"))
 
-    ar = Ts / Tt
+    if Ti > 0
+        ar = Ts / Tt
+    else
+        ar = zero(Ts / Tt)
+    end
     ad = Td / (Td + N * Ts)
     bd = K * N * ad
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,6 +134,7 @@ res2 = lsim(P, ctrl, 3)
 
 # plot([res, res2], plotu=true)
 @test maximum(res2.u) == umax
+@test pid.I == 0.0
 
 
 @test DiscretePID(Ts=1f0) isa DiscretePID{Float32}


### PR DESCRIPTION
Solves #4
I added a test to check that the integral component of the P controller with saturation remains zero. You will notice that this test fails at commit 9ac4d039a591c273a3dd6bc8ed67fa6da78a1077. 

The subsequent commit 211ac8ba328475ef61e8148b140940f0db686d7b fixes the problem and passes all other tests.